### PR TITLE
Fix symlink parent dir escape

### DIFF
--- a/__tests__/symlink-security.test.js
+++ b/__tests__/symlink-security.test.js
@@ -85,4 +85,24 @@ describe("Symlink security tests", () => {
       throw err;
     }
   });
+
+  test("blocks symlink pointing to parent directory", async () => {
+    try {
+      // Symlink that points to the parent directory
+      await fs.symlink("..", join(testRoot, "parent"));
+
+      // Attempt to access a file in the parent directory via the symlink
+      const result = await resolveNocaseSafe(testRoot, ["parent", "secret.txt"]);
+      expect(result).not.toBeNull();
+
+      const safePath = await checkSymlinkSafety(testRoot, result);
+      expect(safePath).toBeNull();
+    } catch (err) {
+      if (err.code === "EPERM" || err.code === "ENOTSUP") {
+        console.log("Skipping symlink test - not supported on this system");
+        return;
+      }
+      throw err;
+    }
+  });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,7 @@ let MAX_CACHE_SIZE = 2000;
 /** Prüft, ob `target` sich noch innerhalb von `base` befindet. */
 function isInside(base, target) {
   const rel = relative(base, target);
-  return rel !== undefined && !rel.startsWith(".." + sep);
+  return rel !== ".." && !rel.startsWith(".." + sep);
 }
 
 /**


### PR DESCRIPTION
## Summary
- tighten `isInside` check
- test symlink targeting parent directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff42a696083209c7757e5d5aee658