### PR TITLE
Add extra range request tests

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -103,6 +103,37 @@ describe("nocase-server integration", () => {
     expect(rangeRes.body.equals(fullRes.body.slice(start))).toBe(true);
   });
 
+  test("supports open-ended range from start", async () => {
+    const fullRes = await request(srv).get("/IMG/logo.png");
+    const fileSize = fullRes.body.length;
+
+    const rangeRes = await request(srv)
+      .get("/IMG/logo.png")
+      .set("Range", "bytes=0-");
+
+    const end = fileSize - 1;
+
+    expect(rangeRes.statusCode).toBe(206);
+    expect(rangeRes.headers["content-range"]).toBe(`bytes 0-${end}/${fileSize}`);
+    expect(rangeRes.body.length).toBe(fileSize);
+  });
+
+  test("supports last-byte range requests", async () => {
+    const fullRes = await request(srv).get("/IMG/logo.png");
+    const fileSize = fullRes.body.length;
+
+    const rangeRes = await request(srv)
+      .get("/IMG/logo.png")
+      .set("Range", "bytes=-50");
+
+    const start = fileSize - 50;
+    const end = fileSize - 1;
+
+    expect(rangeRes.statusCode).toBe(206);
+    expect(rangeRes.headers["content-range"]).toBe(`bytes ${start}-${end}/${fileSize}`);
+    expect(rangeRes.body.length).toBe(50);
+  });
+
   test("handles invalid range requests", async () => {
     const res = await request(srv)
       .get("/IMG/logo.png")


### PR DESCRIPTION
## Summary
- extend integration tests for open-ended byte ranges
- add suffix range tests for last 50 bytes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68470af27fe0832090968930d6585af0